### PR TITLE
Fix UnicodeDecodeError by removing pexcept dependency

### DIFF
--- a/docs/CA_SERVER.md
+++ b/docs/CA_SERVER.md
@@ -22,7 +22,7 @@ A host running one of the below distributions with become privileges:
 
 Other distributions based on Debian or RHEL may also work, but they are not officially supported.
 
-The host must have the `python(3)-pexpect` package installed. This package is installed form the OS repositories automatically when running this role.
+The host must have the `expect` package installed. This package is installed form the OS repositories automatically when running this role.
 
 Role Variables
 --------------

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -1,4 +1,16 @@
 ---
+- name: Install requirements
+  hosts: server-*
+  become: yes
+  tasks:
+  - apt: # noqa 502
+      name: 'python{% if ansible_python.version.major == 3 %}3{% endif %}-pexpect'
+      update_cache: yes
+    when: ansible_os_family == "Debian"
+  - package: # noqa 502
+      name: python3-pexpect
+    when: ansible_os_family == "RedHat"
+
 - name: Create step-ca servers
   hosts: server-*
   roles:

--- a/roles/ca_server/tasks/init.yml
+++ b/roles/ca_server/tasks/init.yml
@@ -46,11 +46,16 @@
     notify: print CA cert fingerprint
 
   - name: Change password for intermediate key
-    expect:
-      command: '{{ stepca_executable_path }}/step crypto change-pass {{ stepca_home }}/.step/secrets/intermediate_ca_key -f'
-      responses:
-        '\bdecrypt\b': '{{ stepca_root_password }}'
-        '\bencrypt\b': '{{ stepca_intermediate_password }}'
+    shell: |
+      set timeout 300
+      spawn {{ stepca_executable_path }}/step crypto change-pass {{ stepca_home }}/.step/secrets/intermediate_ca_key -f
+      expect "decrypt"
+      send "{{ stepca_root_password }}\n"
+      expect "encrypt"
+      send "{{ stepca_intermediate_password }}\n"
+      exit 0
+    args:
+      executable: expect
 
   - name: Remove initial provisioner
     maxhoesel.smallstep.ca_provisioner:

--- a/roles/ca_server/tasks/install.yml
+++ b/roles/ca_server/tasks/install.yml
@@ -42,9 +42,8 @@
     apt:
       name:
         - xz-utils
-        - 'python{% if ansible_python.version.major == 3 %}3{% endif %}-pexpect'
+        - expect
       update_cache: yes
-
   - name: step-ca is installed [Debian]
     apt:
       deb: 'https://github.com/smallstep/certificates/releases/download/v{{ stepca_version }}/step-certificates_{{ stepca_version }}_amd64.deb'
@@ -58,9 +57,8 @@
 
 - block:
   - name: Requirements are installed [EL8]
-    dnf:
-      name: python3-pexpect
-
+    package:
+      name: expect
   - block:
     - name: Download and extract step-ca release [EL]
       unarchive:


### PR DESCRIPTION
The pexept module can sometimes cause errors when running
through the Ansible builtin except module
(https://github.com/ansible/ansible/issues/29351).

To prevent these issues from occuring and messing with the CI,
we remove the except module call and replace it with a shell
call to except directly. This also removes the pexcept package
as a dependency from ca_server.