### PR TITLE
refactor: remove `become` directives from roles

### DIFF
--- a/docs/CA_SERVER.md
+++ b/docs/CA_SERVER.md
@@ -14,7 +14,7 @@ Note that this role does **not** manage the server once it has been created - yo
 Requirements
 ------------
 
-A host running one of the below distributions with become privileges:
+A host running one of the below distributions with `become` privileges:
 
 - Ubuntu 18.04 LTS or newer
 - Debian 10 or newer
@@ -113,6 +113,7 @@ Example Playbook
     stepca_intermediate_password: 'super-secret-intermediate-password'
     # Enable SSH CA support
     stepca_ssh: yes
+  become: yes
 ```
 
 License

--- a/docs/STEP_CLIENT.md
+++ b/docs/STEP_CLIENT.md
@@ -6,7 +6,7 @@ Install the `step` command-line tool on a system
 Requirements
 ------------
 
-A host running one of the below distributions with become privileges:
+A host running one of the below distributions with `become` privileges:
 
 - Ubuntu 18.04 LTS or newer
 - Debian 10 or newer
@@ -32,6 +32,7 @@ Example Playbook
 
 ```
 - hosts: all
+  become: yes
   roles:
   - role: maxhoesel.smallstep.step_client
 ```

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -15,8 +15,10 @@
   hosts: servers
   roles:
   - role: maxhoesel.smallstep.ca_server
+  become: yes
 
 - name: Install step clients
   hosts: clients
   roles:
   - role: maxhoesel.smallstep.step_client
+  become: yes

--- a/roles/ca_server/handlers/main.yml
+++ b/roles/ca_server/handlers/main.yml
@@ -3,7 +3,6 @@
   systemd:
     name: step-ca.service
     state: restarted
-  become: yes
 
 - name: print CA cert fingerprint
   debug:

--- a/roles/ca_server/tasks/install.yml
+++ b/roles/ca_server/tasks/install.yml
@@ -43,4 +43,3 @@
 
 - name: Insatll step-ca and step cli
   include: 'install_{{ ansible_os_family }}.yml'
-  become: yes

--- a/roles/ca_server/tasks/main.yml
+++ b/roles/ca_server/tasks/main.yml
@@ -18,7 +18,6 @@
     shell: /usr/sbin/nologin
     password: '*'
     home: '{{ stepca_home }}'
-  become: yes
 - name: stepca_logdir exists
   file:
     path: '{{ stepca_logdir }}'
@@ -26,19 +25,15 @@
     group: '{{ stepca_user }}'
     state: directory
     mode: 0755
-  become: yes
 
 - name: Look for existing configuration
   stat:
     path: '{{ stepca_home }}/.step/config/ca.json'
   register: stepca_config_file
-  become: yes
 - name: Initialize CA
   include: init.yml
-  become: yes
   become_user: '{{ stepca_user }}'
   when: not stepca_config_file.stat.exists
 
 - name: Setup systemd service
   include: service.yml
-  become: yes

--- a/roles/ca_server/tasks/service.yml
+++ b/roles/ca_server/tasks/service.yml
@@ -5,7 +5,6 @@
     owner: root
     group: root
     mode: 0644
-  become: yes
   notify: restart step-ca
 
 - name: Service is enabled and running

--- a/roles/step_client/tasks/install.yml
+++ b/roles/step_client/tasks/install.yml
@@ -24,4 +24,3 @@
 
 - name: Insatll step cli
   include: 'install_{{ ansible_os_family }}.yml'
-  become: yes

--- a/roles/step_client/tasks/root_cert.yml
+++ b/roles/step_client/tasks/root_cert.yml
@@ -13,23 +13,18 @@
       group: root
       mode: 0755
       state: directory
-    become: yes
 
   - name: Download ca root cert
     command: 'step ca root {{ stepclient_tmpdir }}/{{ item.item.url.split("//").1 }} --ca-url {{ item.item.url }} --fingerprint {{ item.item.fp }}'
-    become: yes
     when: '"CERTIFICATE_VERIFY_FAILED" in item.msg'
     loop: '{{ stepclient_cert_test.results }}'
   - name: Install ca root cert
     command: 'step certificate install {{ stepclient_tmpdir }}/{{ item.item.url.split("//").1 }}'
-    become: yes
     when: '"CERTIFICATE_VERIFY_FAILED" in item.msg'
     loop: '{{ stepclient_cert_test.results }}'
-
   always:
   - name: Temporary certificate folder is absent
     file:
       path: '{{ stepclient_tmpdir }}'
       state: absent
-    become: yes
   when: '"CERTIFICATE_VERIFY_FAILED" in stepclient_cert_test.results | map(attribute="msg") | list | join(",")'


### PR DESCRIPTION
BREAKING CHANGE: From now on, the roles in this collection expect
to be running with root privileges, so you'll need to call them with
`become: yes`. This removes a few edge cases and other issues