### PR TITLE
fix(step_acme_cert): remove community.cryto dep

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -39,8 +39,7 @@ tags: ["smallstep", "ca", "certificates"]
 # collection label 'namespace.name'. The value is a version range
 # L(specifiers,https://python-semanticversion.readthedocs.io/en/latest/#requirement-specification). Multiple version
 # range specifiers can be set and are separated by ','
-dependencies:
-    "community.crypto": ">=1.0,<2.0"
+dependencies: {}
 
 # The URL of the originating SCM repository
 repository: https://github.com/maxhoesel/ansible-collection-smallstep

--- a/roles/step_acme_cert/tasks/main.yml
+++ b/roles/step_acme_cert/tasks/main.yml
@@ -7,15 +7,14 @@
     path: "{{ step_acme_cert_certfile.path }}"
   register: step_acme_cert_current_cert
 
-- name: Check if certificate is expired
-  community.crypto.x509_certificate_info:
-    path: "{{ step_acme_cert_certfile.path }}"
-    valid_at:
-      now: "+0s"
-  register: step_acme_cert_certinfo
+- name: Check if certificate is valid
+  changed_when: no
+  command: "step-cli certificate verify {{ step_acme_cert_certfile.path }}"
+  ignore_errors: true
+  register: _step_acme_cert_validity
   when: step_acme_cert_current_cert.stat.exists
 
 - include: get_cert.yml
-  when: not step_acme_cert_current_cert.stat.exists or not step_acme_cert_certinfo.valid_at.now
+  when: 'not step_acme_cert_current_cert.stat.exists or "failed to verify certificate" in _step_acme_cert_validity.stderr'
 
 - include: renewal.yml


### PR DESCRIPTION
This commit removes the dependency on community.crypto
(and by extension, the cryptography python package).
It turns out that step-cli has all the required functionality built-in,
so we use that instead