### PR TITLE
Don't use privilege escalation when delegating locally

### DIFF
--- a/roles/step_ca/tasks/main.yml
+++ b/roles/step_ca/tasks/main.yml
@@ -9,6 +9,7 @@
         return_content: yes
       register: step_ca_latest_release
       delegate_to: localhost
+      become: no
       run_once: yes
       retries: 3
       delay: 5

--- a/roles/step_cli/tasks/main.yml
+++ b/roles/step_cli/tasks/main.yml
@@ -10,6 +10,7 @@
         return_content: yes
       register: step_cli_latest_release
       delegate_to: localhost
+      become: no
       run_once: yes
       retries: 3
       delay: 5


### PR DESCRIPTION
As described in  #61 , using `become: yes` on tasks with `delegate_to: localhost` can break workflows with different machines having different `sudo` passwords. The only two tasks with this behavior are `uri` modules, that don't require privilege escalation in the first place. This PR seeks to resolve the issue by disabling privilege escalation for those tasks explicitly, as it is not required for the functionality of the `uri` module