### PR TITLE
fix(step_ca_boostrap): don't fail on ubuntu 18.04

### DIFF
--- a/plugins/modules/step_ca_bootstrap.py
+++ b/plugins/modules/step_ca_bootstrap.py
@@ -84,7 +84,7 @@ def run_module():
         try:
             with open(DEFAULTS_FILE, "rb") as f:
                 config = json.load(f)
-        except OSError:
+        except (OSError, IOError):
             # The file probably doesn't exist yet, continue for now
             config = {}
         if config.get("fingerprint", "") == module.params["fingerprint"]:


### PR DESCRIPTION
It seems that only catching OSError isn't sufficient on some systems
and python versions, as this module currently crashes under Ubuntu 18.04
with a FileNotFoundError that is not caught properly. This patch addresses that.