### PR TITLE
fix: add `check_mode: no` for setting facts in `step_ca`

### DIFF
--- a/roles/step_ca/tasks/main.yml
+++ b/roles/step_ca/tasks/main.yml
@@ -17,6 +17,7 @@
       set_fact:
         step_ca_version: "{{ (step_ca_latest_release.json.tag_name)[1:] }}"
   when: step_ca_version == 'latest'
+  check_mode: no
 
 - include: "install.yml"
 


### PR DESCRIPTION
This MR fixes the error in #65 . Setting the facts in that block do no modify the state of any machines, and only registers variables. Enabling this during check mode fixes the error described in #65 and allows for smoother runs while in check mode with  a version set to `latest`