### PR TITLE
Support `--check` mode for all roles once configured

### DIFF
--- a/roles/step_acme_cert/molecule/default/molecule.yml
+++ b/roles/step_acme_cert/molecule/default/molecule.yml
@@ -68,7 +68,7 @@ platforms:
     override_command: false
     pre_build_image: true
     networks:
-     - name: smallstep_acme_cert
+      - name: smallstep_acme_cert
 
   - name: step-cert-centos-8
     hostname: step-cert-centos-8.localdomain
@@ -94,5 +94,21 @@ provisioner:
   inventory:
     links:
       group_vars: ../../../../tests/molecule/group_vars
+
+scenario:
+  test_sequence:
+    - lint
+    - destroy
+    - dependency
+    - syntax
+    - create
+    - prepare
+    - converge
+    - idempotence
+    - check # also run check mode in regular tests
+    - side_effect
+    - verify
+    - destroy
+
 verifier:
   name: ansible

--- a/roles/step_acme_cert/tasks/main.yml
+++ b/roles/step_acme_cert/tasks/main.yml
@@ -9,6 +9,7 @@
 
 - name: Check if certificate is valid
   changed_when: no
+  check_mode: no
   command: "step-cli certificate verify {{ step_acme_cert_certfile.path }}"
   ignore_errors: true
   register: _step_acme_cert_validity

--- a/roles/step_bootstrap_host/molecule/default/molecule.yml
+++ b/roles/step_bootstrap_host/molecule/default/molecule.yml
@@ -68,7 +68,7 @@ platforms:
     override_command: false
     pre_build_image: true
     networks:
-     - name: smallstep_bootstrap_host
+      - name: smallstep_bootstrap_host
 
   - name: step-host-centos-8
     hostname: step-host-centos-8.localdomain
@@ -94,5 +94,21 @@ provisioner:
   inventory:
     links:
       group_vars: ../../../../tests/molecule/group_vars
+
+scenario:
+  test_sequence:
+    - lint
+    - destroy
+    - dependency
+    - syntax
+    - create
+    - prepare
+    - converge
+    - idempotence
+    - check # also run check mode in regular tests
+    - side_effect
+    - verify
+    - destroy
+
 verifier:
   name: ansible

--- a/roles/step_ca/molecule/default/molecule.yml
+++ b/roles/step_ca/molecule/default/molecule.yml
@@ -64,5 +64,21 @@ provisioner:
   inventory:
     links:
       group_vars: ../../../../tests/molecule/group_vars
+
+scenario:
+  test_sequence:
+    - lint
+    - destroy
+    - dependency
+    - syntax
+    - create
+    - prepare
+    - converge
+    - idempotence
+    - check # also run check mode in regular tests
+    - side_effect
+    - verify
+    - destroy
+
 verifier:
   name: ansible

--- a/roles/step_ca/tasks/main.yml
+++ b/roles/step_ca/tasks/main.yml
@@ -17,6 +17,7 @@
       set_fact:
         step_ca_version: "{{ (step_ca_latest_release.json.tag_name)[1:] }}"
   when: step_ca_version == 'latest'
+  check_mode: no
 
 - include: "install.yml"
 

--- a/roles/step_cli/molecule/default/molecule.yml
+++ b/roles/step_cli/molecule/default/molecule.yml
@@ -57,5 +57,21 @@ provisioner:
   inventory:
     links:
       group_vars: ../../../../tests/molecule/group_vars
+
+scenario:
+  test_sequence:
+    - lint
+    - destroy
+    - dependency
+    - syntax
+    - create
+    - prepare
+    - converge
+    - idempotence
+    - check # also run check mode in regular tests
+    - side_effect
+    - verify
+    - destroy
+
 verifier:
   name: ansible

--- a/roles/step_cli/tasks/capabilities.yml
+++ b/roles/step_cli/tasks/capabilities.yml
@@ -5,6 +5,7 @@
 - name: Get binary capabilities
   command: "getcap {{ step_cli_executable }}"
   changed_when: no
+  check_mode: no
   register: step_cli_binary_capabilities
 - name: Set CAP_NET_BIND_SERVICE capability for step-cli to bind to ports <1024 for ACME protocol
   command: "setcap CAP_NET_BIND_SERVICE=+eip {{ step_cli_executable }}"

--- a/roles/step_cli/tasks/main.yml
+++ b/roles/step_cli/tasks/main.yml
@@ -18,6 +18,7 @@
       set_fact:
         step_cli_version: "{{ (step_cli_latest_release.json.tag_name)[1:] }}"
   when: step_cli_version == 'latest'
+  check_mode: no
 
 - include: "install.yml"
 - include: "capabilities.yml"


### PR DESCRIPTION
This change introduces support for running all roles in this collection in --check mode after being run normally at least once. This is useful in CI/CD workflows where changes are first tested in a `--check` dry-run before then being applied. See https://github.com/maxhoesel/ansible-collection-smallstep/issues/65 for more background on this.

Note that this change does not enable dry-run installations from scratch.

This PR also includes https://github.com/maxhoesel/ansible-collection-smallstep/pull/66