### PR TITLE
feat(step_ca_bootstrap): fail bootstrap if fingerprint mismatch (#74)

### DIFF
--- a/plugins/modules/step_ca_bootstrap.py
+++ b/plugins/modules/step_ca_bootstrap.py
@@ -88,7 +88,11 @@ def run_module():
             # The file probably doesn't exist yet, continue for now
             config = {}
         if config.get("fingerprint", "") == module.params["fingerprint"]:
-            result["msg"] = "Already bootstrapped and force not set"
+            result["msg"] = "Already bootstrapped and force not set."
+            module.exit_json(**result)
+        elif config.get("fingerprint", module.params["fingerprint"]) != module.params["fingerprint"]:
+            result["msg"] = "Already bootstrapped to a different CA, and force not set."
+            result["failed"] = True
             module.exit_json(**result)
 
     args = {


### PR DESCRIPTION
The module `step_ca_boostrap` will now (properly) fail if the CA already configured on the client does not match the fingerprint provided to the module.

/resolves #74