### PR TITLE
feat(step_boostrap_host): pass `force` to underlying module (#73)

### DIFF
--- a/roles/step_bootstrap_host/README.md
+++ b/roles/step_bootstrap_host/README.md
@@ -46,6 +46,10 @@ This role is intended to be run on regular hosts in your network that you want t
 - If set to false, this role only installs `step-cli` and configures the root user to run `step-cli` against your CA
 - Default: Yes
 
+##### `step_bootstrap_force`
+- Whether to force bootstrapping of the CA configuration.
+- If true, will cause an overwrite of any existing CA configuration, including root certificate.  Useful to change the CA URL, or even change to a new CA entirely.
+- Default: No
 
 ## Example Playbook
 

--- a/roles/step_bootstrap_host/defaults/main.yml
+++ b/roles/step_bootstrap_host/defaults/main.yml
@@ -5,3 +5,4 @@ step_cli_executable: step-cli
 #step_bootstrap_fingerprint:
 
 step_bootstrap_install_cert: yes
+step_bootstrap_force: no

--- a/roles/step_bootstrap_host/tasks/main.yml
+++ b/roles/step_bootstrap_host/tasks/main.yml
@@ -6,6 +6,7 @@
     ca_url: "{{ step_bootstrap_ca_url }}"
     fingerprint: "{{ step_bootstrap_fingerprint }}"
     step_cli_executable: "{{ step_cli_executable }}"
+    force: "{{ step_bootstrap_force | d(omit) }}"
   become: yes
 
 - name: check if cert is already installed
@@ -24,4 +25,6 @@
         owner: root
         group: root
         mode: "640"
-  when: step_bootstrap_install_cert and not step_bootstrap_installed.stat.exists
+  when:
+    - step_bootstrap_install_cert
+    - step_bootstrap_force or not step_bootstrap_installed.stat.exists


### PR DESCRIPTION
The module (`step_ca_boostrap.py`) underlying the `step_boostrap_role` has an `force` option, but it is not exposed in the role.  This creates a variable for role users to modify, which defaults to `no`, and passes that value to the module.  Documentation has been added as well.

This feature allows one to change the CA URL or point at a different CA simply by calling the `bootstrap` role again.

/resolves #73