### PR TITLE
feat(step_acme_cert): better default value support for cert gen (#81)

### DIFF
--- a/roles/step_acme_cert/defaults/main.yml
+++ b/roles/step_acme_cert/defaults/main.yml
@@ -10,12 +10,14 @@ step_acme_cert_san: []
 #step_acme_cert_duration: 24h
 step_acme_cert_contact: root@localhost
 
-step_acme_cert_certfile:
+step_acme_cert_certfile: "{{ step_acme_cert_certfile_defaults }}"
+step_acme_cert_certfile_defaults:
   path: /etc/ssl/step.crt
   mode: "644"
   owner: root
   group: root
-step_acme_cert_keyfile:
+step_acme_cert_keyfile: "{{ step_acme_cert_keyfile_defaults }}"
+step_acme_cert_keyfile_defaults:
   path: /etc/ssl/step.key
   mode: "600"
   owner: root

--- a/roles/step_acme_cert/tasks/get_cert.yml
+++ b/roles/step_acme_cert/tasks/get_cert.yml
@@ -20,5 +20,5 @@
     owner: "{{ item.owner }}"
     group: "{{ item.group }}"
   loop:
-    - "{{ step_acme_cert_keyfile }}"
-    - "{{ step_acme_cert_certfile }}"
+    - "{{ step_acme_cert_keyfile_defaults | combine(step_acme_cert_keyfile) }}"
+    - "{{ step_acme_cert_certfile_defaults | combine(step_acme_cert_certfile) }}"


### PR DESCRIPTION
Use the `| combine(dict)` feature of Jinja to support full defaults for the `step_acme_cert_certfile` and `_keyfile` variables.  Now, only the keys that need overriding need a value. E.g. instead of:

    - name: step-client | test cert creation and renewal
      include_role:
        name: maxhoesel.smallstep.step_acme_cert
      vars:
        step_acme_cert_certfile:
          path: "{{ step_cert_directory }}/step-test-cert.crt"
          owner: root
          group: root
          mode: 644
        step_acme_cert_keyfile:
          path: "{{ step_cert_directory }}/step-test-cert.key"
          owner: root
          group: root
          mode: 600

... one can simplify to only:

    - name: step-client | test cert creation and renewal
      include_role:
        name: maxhoesel.smallstep.step_acme_cert
      vars:
        step_acme_cert_certfile:
          path: "{{ step_cert_directory }}/step-test-cert.crt"
        step_acme_cert_keyfile:
          path: "{{ step_cert_directory }}/step-test-cert.key"

/resolves #81