### PR TITLE
fix(step_ca): eliminate spurious Ansible "password" warnings

### DIFF
--- a/plugins/modules/step_ca_certificate.py
+++ b/plugins/modules/step_ca_certificate.py
@@ -187,7 +187,7 @@ def run_module():
         not_after=dict(type="str"),
         not_before=dict(type="str"),
         provisioner=dict(type="str", aliases=["issuer"], required=True),
-        provisioner_password_file=dict(type="path"),
+        provisioner_password_file=dict(type="path", no_log=False),
         san=dict(type="list", elements="str"),
         set=dict(type="list", elements="str"),
         set_file=dict(type="path"),

--- a/plugins/modules/step_ca_token.py
+++ b/plugins/modules/step_ca_token.py
@@ -163,7 +163,7 @@ def run_module():
         output_file=dict(type="path"),
         principal=dict(type="list", elements="str"),
         provisioner=dict(type="str", aliases=["issuer"]),
-        provisioner_password_file=dict(type="path"),
+        provisioner_password_file=dict(type="path", no_log=False),
         return_token=dict(type="bool"),
         revoke=dict(type="bool"),
         renew=dict(type="bool"),

--- a/tests/integration/targets/setup_smallstep/tasks/main.yml
+++ b/tests/integration/targets/setup_smallstep/tasks/main.yml
@@ -4,46 +4,48 @@
   register: install_finished
 
 - block:
-  - name: Install sudo
-    package:
-      name: sudo
-      state: present
+    - name: Load smallstep test version numbers
+      include_vars: vars/versions.yml
 
-  - name: Install step-cli
-    include_role:
-      name: maxhoesel.smallstep.step_cli
+    - name: Install sudo
+      package:
+        name: sudo
+        state: present
 
-  - name: Copy existing ca cert/key to nodes
-    copy:
-      src: "{{ item }}"
-      dest: /tmp/
-      owner: root
-      group: root
-      mode: 0755
-    loop:
-      - "existing.crt"
-      - "existing.key"
+    - name: Install step-cli
+      include_role:
+        name: maxhoesel.smallstep.step_cli
 
-  - name: Install step-ca
-    include_role:
-      name: maxhoesel.smallstep.step_ca
-    vars:
-      step_ca_name: module-tests
-      step_ca_root_password: "{{ step_ca_password }}"
-      step_ca_dns: "127.0.0.1"
-      step_ca_ssh: yes
-      step_ca_existing_root_file: /tmp/existing.crt
-      step_ca_existing_key_file: /tmp/existing.key
+    - name: Copy existing ca cert/key to nodes
+      copy:
+        src: "{{ item }}"
+        dest: /tmp/
+        owner: root
+        group: root
+        mode: 0755
+      loop:
+        - "existing.crt"
+        - "existing.key"
 
-  - name: Bootstrap host
-    include_role:
-      name: maxhoesel.smallstep.step_bootstrap_host
-    vars:
-      step_bootstrap_ca_url: "{{ step_ca_url }}"
-      step_bootstrap_fingerprint: "{{ step_ca_fingerprint }}"
+    - name: Install step-ca
+      include_role:
+        name: maxhoesel.smallstep.step_ca
+      vars:
+        step_ca_name: module-tests
+        step_ca_root_password: "{{ step_ca_password }}"
+        step_ca_dns: "127.0.0.1"
+        step_ca_ssh: yes
+        step_ca_existing_root_file: /tmp/existing.crt
+        step_ca_existing_key_file: /tmp/existing.key
+    - name: Bootstrap host
+      include_role:
+        name: maxhoesel.smallstep.step_bootstrap_host
+      vars:
+        step_bootstrap_ca_url: "{{ step_ca_url }}"
+        step_bootstrap_fingerprint: "{{ step_ca_fingerprint }}"
 
-  - name: Install_completed file is present
-    copy:
-      content: "install finished"
-      dest: /tmp/install_finished
+    - name: Install_completed file is present
+      copy:
+        content: "install finished"
+        dest: /tmp/install_finished
   when: not install_finished.stat.exists

--- a/tests/integration/targets/setup_smallstep/vars/versions.yml
+++ b/tests/integration/targets/setup_smallstep/vars/versions.yml
@@ -1,0 +1,2 @@
+step_ca_version: "0.15.16"
+step_cli_version: "0.15.17"


### PR DESCRIPTION
Added `no_log=False` to a couple of places where the name of the variables look like passwords, but are not.

FIXES: #75