### PR TITLE
fix(step_bootstrap_host): support STEPPATH ENV VAR

### DIFF
--- a/roles/step_bootstrap_host/tasks/main.yml
+++ b/roles/step_bootstrap_host/tasks/main.yml
@@ -9,17 +9,14 @@
     force: "{{ step_bootstrap_force | d(omit) }}"
   become: yes
 
-# Ansibles env lookup always looks at the connection users env vars.
-# Since we need to check the root users home dir, we check manually
-- name: Get root user home directory
-  shell: echo $HOME
-  register: step_bootstrap_root_home
-  become: yes
-  changed_when: no
-  check_mode: no
+# This requires that facts are gathered, because of the use of `ansible_env`.
+# But can't use `lookup(env, ...)`, since that doesn't query remote system.
+- name: Calculate location of CA root certificate file
+  set_fact:
+    _bootstrap_root_cert_file: "{{ (ansible_env.STEPPATH | d(ansible_env.HOME + '/.step', true)) + '/certs/root_ca.crt' }}"
 
-- name: check if cert is already installed
-  command: "{{ step_cli_executable }} certificate verify {{ lookup('env', 'STEPPATH') | default(step_bootstrap_root_home.stdout + '/.step', true) }}/certs/root_ca.crt"
+- name: Check if root CA cert is already installed
+  command: "{{ step_cli_executable }} certificate verify {{ _bootstrap_root_cert_file }}"
   become: yes
   changed_when: no
   check_mode: no
@@ -28,7 +25,7 @@
   when: step_bootstrap_install_cert
 
 - name: Install CA cert into trust stores
-  command: "step-cli certificate install /root/.step/certs/root_ca.crt --all"
+  command: "step-cli certificate install {{ _bootstrap_root_cert_file }} --all"
   when:
     - step_bootstrap_install_cert
     - step_bootstrap_force or step_bootstrap_installed.failed


### PR DESCRIPTION
This amends the checks and installation of STEP CA Root certificate to use STEPPATH if set.  If not set, will mimic the `step-cli` behavior and default to `$HOME/.step`.

Note that the previous implementation utilized the ansible `lookup(env, 'STEPPATH')` filter, but that will not work for environment variables set via the `environment:` block, per the documentation:

https://docs.ansible.com/ansible/latest/user_guide/playbooks_environment.html

> The environment: keyword does not affect Ansible itself, Ansible
> configuration settings, the environment for other users, or the
> execution of other plugins like lookups and filters.

What this does allow is setting of the environment variable at a play or task level; e.g.:

```yaml
- hosts: step_client
  become: yes
  environment:
    STEPPATH: "{{ my_steppath }}"
  tasks:
   [...]
```

I thought about adding that as an example to the documentation, but then I also thought that perhaps a specific variable definition for STEPPATH (e.g. `step_cli_steppath`, mirroring `step_ca_path`) would be a better solution.

BTW: I have tested and am actively using the example above currently.  