### PR TITLE
fix(step_ca): make unset defaults actually undefined instead of ""

### DIFF
--- a/roles/step_acme_cert/README.md
+++ b/roles/step_acme_cert/README.md
@@ -44,7 +44,7 @@ before setting up a renewal service using `step-cli ca renew`s `--daemon` mode.
 ##### `step_acme_cert_san`
 - Subject Alternate Names to add to the cert
 - Must be a list of valid SANs
-- Default: `[ {{ ansible_default_ipv4.address }} ]`
+- Default: `[]`
 
 ##### `step_acme_cert_duration`
 - Valid duration of the certificate

--- a/roles/step_ca/README.md
+++ b/roles/step_ca/README.md
@@ -95,7 +95,7 @@ See the [step docs](https://smallstep.com/docs/step-cli/reference/ca/init) for m
 
 ##### `step_ca_url`
 - URI of the Step Certificate Authority to write in defaults.json
-- Default: `""`
+- Default: Not set
 
 ##### `step_ca_ssh`
 - Create keys to sign SSH certificates
@@ -110,13 +110,13 @@ These variables need to be set as a group.
 ##### `step_ca_existing_root_file`
 - The path of an existing PEM file to be used as the root certificate authority
 - The file must already exist on the remote host
-- Default: `""`
+- Default: Not set
 
 ##### `step_ca_existing_key_file`
 - The path of an existing key file of the root certificate authority
 - The key file must not be password-protected
 - The file must already exist on the remote host
-- Default: `""`
+- Default: Not set
 
 
 #### RA Variables
@@ -126,15 +126,15 @@ These variables need to be set as a group
 
 ##### `step_ca_ra`
 - The registration authority name to use. Currently only "CloudCAS" is supported
-- Default: `""`
+- Default: Not set
 
 ##### `step_ca_ra_issuer`
 - The registration authority issuer name to use
-- Default: `""`
+- Default: Not set
 
 ##### `step_ca_ra_credentials_file`
 - The registration authority credentials file to use
-- Default: `""`
+- Default: Not set
 
 
 ### step-cli

--- a/roles/step_ca/defaults/main.yml
+++ b/roles/step_ca/defaults/main.yml
@@ -11,14 +11,14 @@ step_ca_path: /etc/step-ca
 step_ca_dns: "{{ ansible_fqdn }},{{ ansible_default_ipv4.address }}"
 step_ca_address: ":443"
 
-step_ca_existing_root_file: ""
-step_ca_existing_key_file: ""
-step_ca_url: ""
+#step_ca_existing_root_file:
+#step_ca_existing_key_file:
+#step_ca_url:
 step_ca_ssh: false
 
-step_ca_ra: ""
-step_ca_ra_issuer: ""
-step_ca_ra_credentials_file: ""
+#step_ca_ra:
+#step_ca_ra_issuer:
+#step_ca_ra_credentials_file:
 
 # CLI vars
 step_cli_executable: step-cli

--- a/roles/step_ca/tasks/check.yml
+++ b/roles/step_ca/tasks/check.yml
@@ -15,8 +15,8 @@
       - step_ca_existing_key_file | length > 0
     fail_msg: Existing root cert/key variables must be passed as a group
   when: >
-    step_ca_existing_root_file | length > 0 or
-    step_ca_existing_key_file | length > 0
+    step_ca_existing_root_file is defined or
+    step_ca_existing_key_file is defined
 
 - name: Verify RA variables
   assert:
@@ -26,9 +26,9 @@
       - step_ca_ra_credentials_file | length > 0
     fail_msg: RA variables must be passed as a group
   when: >
-    step_ca_ra | length > 0 or
-    step_ca_ra_issuer | length > 0 or
-    step_ca_ra_credentials_file | length > 0
+    step_ca_ra is defined or
+    step_ca_ra_issuer is defined or
+    step_ca_ra_credentials_file is defined
 
 - name: set step_ca_intermediate_password
   set_fact:

--- a/roles/step_ca/tasks/init.yml
+++ b/roles/step_ca/tasks/init.yml
@@ -17,15 +17,15 @@
         - "--password-file='{{ step_ca_root_password_file }}'"
         - "--provisioner-password-file='{{ step_ca_root_password_file }}'"
         # Optional parameters simply pass an empty string as an argument if they're not defined
-        - "{% if step_ca_url %}--with-ca-url='{{ step_ca_url }}'{% else %}''{% endif %}"
+        - "{% if step_ca_url is defined %}--with-ca-url='{{ step_ca_url }}'{% else %}''{% endif %}"
         - "{% if step_ca_ssh %}--ssh{% else %}''{% endif %}"
         # Existing keychain
-        - "{% if step_ca_existing_root_file %}--root='{{ step_ca_existing_root_file }}'{% else %}''{% endif %}"
-        - "{% if step_ca_existing_key_file %}--key='{{ step_ca_existing_key_file }}'{% else %}''{% endif %}"
+        - "{% if step_ca_existing_root_file is defined %}--root='{{ step_ca_existing_root_file }}'{% else %}''{% endif %}"
+        - "{% if step_ca_existing_key_file is defined %}--key='{{ step_ca_existing_key_file }}'{% else %}''{% endif %}"
         # RA variables
-        - "{% if step_ca_ra %}--ra='{{ step_ca_ra }}'{% else %}''{% endif %}"
-        - "{% if step_ca_ra_issuer %}--issuer='{{ step_ca_ra_issuer }}'{% else %}''{% endif %}"
-        - "{% if step_ca_ra_credentials_file %}--credentials-file='{{ step_ca_ra_credentials_file }}'{% else %}''{% endif %}"
+        - "{% if step_ca_ra is defined %}--ra='{{ step_ca_ra }}'{% else %}''{% endif %}"
+        - "{% if step_ca_ra_issuer is defined %}--issuer='{{ step_ca_ra_issuer }}'{% else %}''{% endif %}"
+        - "{% if step_ca_ra_credentials_file is defined %}--credentials-file='{{ step_ca_ra_credentials_file }}'{% else %}''{% endif %}"
 
     - name: Create root and intermediate password files
       copy:


### PR DESCRIPTION
This PR switches the undefined-by-default variables in `step_ca` (such as `step_ca_url`) from empty strings to actual undefined variables. The main motivation for this change is consistency and readability - these values aren't just empty by default, they don't exist in the first place.