### PR TITLE
fix: eliminate "expected errors" when looking for step-cli/certs

### DIFF
--- a/roles/step_acme_cert/tasks/check.yml
+++ b/roles/step_acme_cert/tasks/check.yml
@@ -5,13 +5,15 @@
       - step_acme_cert_ca_provisioner | length > 0
   when: ansible_version.string is version('2.11.1', '<')
 
-- name: Look for step_cli_executable
-  command: "{{ step_cli_executable }} version"
-  ignore_errors: yes
+- name: Look for step_cli_executable # noqa command-instead-of-shell
+  #"command" is a shell builtin, hence the need for the shell module
+  shell: "command -v {{ step_cli_executable }}"
+  register: step_cli_install
+  # dash (Debian sh shell) uses 127 instead of 1 for not found errors
+  failed_when: step_cli_install.rc not in [0,1,127]
   changed_when: no
   check_mode: no
-  register: step_cli_install
 - name: Verify that `step-cli` is installed
   assert:
-    that: not step_cli_install.failed
-    fail_msg: "could not find {{ step_cli_executable }}. Please install it with maxhoesel.smallstep.step_cli first"
+    that: step_cli_install.rc == 0
+    fail_msg: "Could not find step-cli at path '{{ step_cli_executable }}'. Please install step-cli via maxhoesel.smallstep.step_cli or step_bootstrap_host"

--- a/roles/step_bootstrap_host/molecule/default/verify.yml
+++ b/roles/step_bootstrap_host/molecule/default/verify.yml
@@ -12,8 +12,5 @@
     - name: Attempt to access CA URL
       uri:
         url: https://step-ca.localdomain
-      ignore_errors: yes
+      failed_when: ca_query.status != 404
       register: ca_query
-    - name: Verify that SSL handshake was successful
-      assert:
-        that: not ca_query.failed or ca_query.status == 404

--- a/roles/step_bootstrap_host/tasks/check.yml
+++ b/roles/step_bootstrap_host/tasks/check.yml
@@ -7,13 +7,15 @@
       - step_bootstrap_fingerprint | length > 0
   when: ansible_version.string is version('2.11.1', '<')
 
-- name: Look for step_cli_executable
-  command: "{{ step_cli_executable }} version"
-  ignore_errors: yes
+- name: Look for step_cli_executable # noqa command-instead-of-shell
+  #"command" is a shell builtin, hence the need for the shell module
+  shell: "command -v {{ step_cli_executable }}"
+  register: step_cli_install
+  # dash (Debian sh shell) uses 127 instead of 1 for not found errors
+  failed_when: step_cli_install.rc not in [0,1,127]
   changed_when: no
   check_mode: no
-  register: step_cli_install
 - name: Install step_cli
   include_role:
     name: maxhoesel.smallstep.step_cli
-  when: step_cli_install.failed
+  when: step_cli_install.rc != 0

--- a/roles/step_bootstrap_host/tasks/main.yml
+++ b/roles/step_bootstrap_host/tasks/main.yml
@@ -24,7 +24,7 @@
   become: yes
   changed_when: no
   check_mode: no
-  ignore_errors: yes
+  failed_when: step_bootstrap_installed.rc not in [0,1]
   register: step_bootstrap_installed
   when: step_bootstrap_install_cert
 
@@ -32,4 +32,4 @@
   command: "step-cli certificate install {{ step_cli_steppath }}/certs/root_ca.crt --all"
   when:
     - step_bootstrap_install_cert
-    - step_bootstrap_force or step_bootstrap_installed.failed
+    - step_bootstrap_force or step_bootstrap_installed.rc != 0

--- a/roles/step_ca/tasks/check.yml
+++ b/roles/step_ca/tasks/check.yml
@@ -36,13 +36,15 @@
     step_ca_intermediate_password: "{{ step_ca_root_password }}"
   when: not step_ca_intermediate_password is defined
 
-- name: Look for step_cli_executable
-  command: "{{ step_cli_executable }} version"
-  ignore_errors: yes
+- name: Look for step_cli_executable # noqa command-instead-of-shell
+  #"command" is a shell builtin, hence the need for the shell module
+  shell: "command -v {{ step_cli_executable }}"
+  register: step_cli_install
+  # dash (Debian sh shell) uses 127 instead of 1 for not found errors
+  failed_when: step_cli_install.rc not in [0,1,127]
   changed_when: no
   check_mode: no
-  register: step_cli_install
 - name: Install step_cli
   include_role:
     name: maxhoesel.smallstep.step_cli
-  when: step_cli_install.failed
+  when: step_cli_install.rc != 0


### PR DESCRIPTION
When looking for the step-cli at the begging of a role,
we can use the "command" shell builtin to check for the binaries presence
instead of calling it directly.

This has the advantage of elminating the ugly "failed" task that would
normally occur when running the step_cli or step_bootstrap_hosts roles
for the first time. For consistencys sake, we also use this new method
in roles like step_acme_cert that error out upon not finding step-cli.

We can use the same pattern to also catch the error thrown by step-cli
upon finding an invalid/not-yet-installed ca cert in step_bootstrap_host.

Fixes https://github.com/maxhoesel/ansible-collection-smallstep/issues/96,