### PR TITLE
test: simplify the molecule platform defs

### DIFF
--- a/roles/step_acme_cert/molecule/default/molecule.yml
+++ b/roles/step_acme_cert/molecule/default/molecule.yml
@@ -7,24 +7,15 @@ driver:
     - name: smallstep_acme_cert
       driver: bridge
 platforms:
-  # Note on containers:
-  # - We use the images provided by geerlingguy, as they provide out-of-the-box
-  #   support for Ansible and systemd (needed to test service management).
-  # - The containers run as privileged containers so that we can
-  #   use systemd functionality. This *should* be possible with unpriliged
-  #   containers as well, but is quite the headache.
-  # - they are connected to a shared network to allow simulating a remote CA
   - name: step-ca
     hostname: step-ca.localdomain
     groups:
       - ca
       - ubuntu
     image: "geerlingguy/docker-ubuntu2004-ansible"
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
     privileged: true
-    override_command: false
     pre_build_image: true
+    override_command: false
     networks:
       - name: smallstep_acme_cert
 
@@ -34,11 +25,9 @@ platforms:
       - clients
       - ubuntu
     image: "geerlingguy/docker-ubuntu2004-ansible"
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
     privileged: true
-    override_command: false
     pre_build_image: true
+    override_command: false
     networks:
       - name: smallstep_acme_cert
 
@@ -48,11 +37,9 @@ platforms:
       - clients
       - ubuntu
     image: "geerlingguy/docker-ubuntu1804-ansible"
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
     privileged: true
-    override_command: false
     pre_build_image: true
+    override_command: false
     networks:
       - name: smallstep_acme_cert
 
@@ -62,11 +49,9 @@ platforms:
       - clients
       - debian
     image: "geerlingguy/docker-debian10-ansible"
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
     privileged: true
-    override_command: false
     pre_build_image: true
+    override_command: false
     networks:
       - name: smallstep_acme_cert
 
@@ -79,8 +64,8 @@ platforms:
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     privileged: true
-    override_command: false
     pre_build_image: true
+    override_command: false
     networks:
       - name: smallstep_acme_cert
 

--- a/roles/step_bootstrap_host/molecule/default/molecule.yml
+++ b/roles/step_bootstrap_host/molecule/default/molecule.yml
@@ -7,24 +7,15 @@ driver:
     - name: smallstep_bootstrap_host
       driver: bridge
 platforms:
-  # Note on containers:
-  # - We use the images provided by geerlingguy, as they provide out-of-the-box
-  #   support for Ansible and systemd (needed to test service management).
-  # - The containers run as privileged containers so that we can
-  #   use systemd functionality. This *should* be possible with unpriliged
-  #   containers as well, but is quite the headache.
-  # - they are connected to a shared network to allow simulating a remote CA
   - name: step-ca
     hostname: step-ca.localdomain
     groups:
       - ca
       - ubuntu
     image: "geerlingguy/docker-ubuntu2004-ansible"
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
     privileged: true
-    override_command: false
     pre_build_image: true
+    override_command: false
     networks:
       - name: smallstep_bootstrap_host
 
@@ -34,11 +25,9 @@ platforms:
       - clients
       - ubuntu
     image: "geerlingguy/docker-ubuntu2004-ansible"
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
     privileged: true
-    override_command: false
     pre_build_image: true
+    override_command: false
     networks:
       - name: smallstep_bootstrap_host
 
@@ -48,11 +37,9 @@ platforms:
       - clients
       - ubuntu
     image: "geerlingguy/docker-ubuntu1804-ansible"
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
     privileged: true
-    override_command: false
     pre_build_image: true
+    override_command: false
     networks:
       - name: smallstep_bootstrap_host
 
@@ -62,11 +49,9 @@ platforms:
       - clients
       - debian
     image: "geerlingguy/docker-debian10-ansible"
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
     privileged: true
-    override_command: false
     pre_build_image: true
+    override_command: false
     networks:
       - name: smallstep_bootstrap_host
 
@@ -76,11 +61,9 @@ platforms:
       - clients
       - centos
     image: "geerlingguy/docker-centos8-ansible"
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
     privileged: true
-    override_command: false
     pre_build_image: true
+    override_command: false
     networks:
       - name: smallstep_bootstrap_host
 

--- a/roles/step_ca/molecule/default/molecule.yml
+++ b/roles/step_ca/molecule/default/molecule.yml
@@ -4,55 +4,41 @@ dependency:
 driver:
   name: docker
 platforms:
-  # Note on containers:
-  # - We use the images provided by geerlingguy, as they provide out-of-the-box
-  #   support for Ansible and systemd (needed to test service management).
-  # - The containers run as privileged containers so that we can
-  #   use systemd functionality. This *should* be possible with unpriliged
-  #   containers as well, but is quite the headache.
   - name: step-ca-ubuntu-20
     groups:
       - ubuntu
       - ca
     image: "geerlingguy/docker-ubuntu2004-ansible"
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
     privileged: true
-    override_command: false
     pre_build_image: true
+    override_command: false
 
   - name: step-ca-ubuntu-18
     groups:
       - ubuntu
       - ca
     image: "geerlingguy/docker-ubuntu1804-ansible"
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
     privileged: true
-    override_command: false
     pre_build_image: true
+    override_command: false
 
   - name: step-ca-debian-10
     groups:
       - debian
       - ca
     image: "geerlingguy/docker-debian10-ansible"
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
     privileged: true
-    override_command: false
     pre_build_image: true
+    override_command: false
 
   - name: step-ca-centos-8
     groups:
       - centos
       - ca
     image: "geerlingguy/docker-centos8-ansible"
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
     privileged: true
-    override_command: false
     pre_build_image: true
+    override_command: false
 
 provisioner:
   name: ansible

--- a/roles/step_cli/molecule/default/molecule.yml
+++ b/roles/step_cli/molecule/default/molecule.yml
@@ -4,48 +4,34 @@ dependency:
 driver:
   name: docker
 platforms:
-  # Note on containers:
-  # - We use the images provided by geerlingguy, as they provide out-of-the-box
-  #   support for Ansible and systemd (needed to test service management).
-  # - The containers run as privileged containers so that we can
-  #   use systemd functionality. This *should* be possible with unpriliged
-  #   containers as well, but is quite the headache.
   - name: step-cli-ubuntu-20
     image: "geerlingguy/docker-ubuntu2004-ansible"
     groups:
       - ubuntu
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
     privileged: true
-    override_command: false
     pre_build_image: true
+    override_command: false
   - name: step-cli-ubuntu-18
     image: "geerlingguy/docker-ubuntu1804-ansible"
     groups:
       - ubuntu
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
     privileged: true
-    override_command: false
     pre_build_image: true
+    override_command: false
   - name: step-cli-debian-10
     image: "geerlingguy/docker-debian10-ansible"
     groups:
       - debian
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
     privileged: true
-    override_command: false
     pre_build_image: true
+    override_command: false
   - name: step-cli-centos-8
     image: "geerlingguy/docker-centos8-ansible"
     groups:
       - centos
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
     privileged: true
-    override_command: false
     pre_build_image: true
+    override_command: false
 
 provisioner:
   name: ansible


### PR DESCRIPTION
These parameters are not needed as they are  already implicitly
set in the docker images. We can thus remove them safely.