### PR TITLE
ci: remove tox-ansible workaround

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,10 +64,6 @@ jobs:
       - name: Install tox
         run: sudo apt update && sudo apt install -y tox
 
-        # Temporary fix for: https://github.com/maxhoesel/ansible-collection-smallstep/issues/100
-      - name: Install tox-ansible manually
-        run: pip3 install git+https://github.com/ansible-community/tox-ansible@8d0e3cfe31899b9d735f1b879deb1abdfb3673e9#egg=tox-ansible
-
       - name: Run sanity tests
         run: tox -e sanity -- --docker --color -v --python 3.6
       - name: Run integration tests

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist=lint
 requires =
-    tox-ansible>=1.0,<2.0
+    tox-ansible>=1.6,<2.0
 skipsdist = True
 
 [gh-actions]


### PR DESCRIPTION
With release 1.6 out, we can now install tox-ansible regularly again.

Fixes https://github.com/maxhoesel/ansible-collection-smallstep/issues/100